### PR TITLE
zobov.py - fix bug that moves all files if handle is empty

### DIFF
--- a/python_tools/zobov.py
+++ b/python_tools/zobov.py
@@ -29,10 +29,13 @@ class ZobovVoids:
         self.verbose=verbose
 
         # the prefix/handle used for all output file names
-        self.handle = handle
+        if handle in (None,'') or not myString.strip():
+            self.handle = "myhandle" # default handle if empty
+        else:
+            self.handle = handle
 
         # output folder
-        self.output_folder = output_folder
+        self.output_folder = os.path.join(output_folder,'') # add a trailing slash if needed
         if not os.access(self.output_folder, os.F_OK):
             os.makedirs(self.output_folder)
 


### PR DESCRIPTION
An empty value of `handle` in `parameters/params.py` can cause
zobov to shift all files from the Revolver/ main directory into a
subsubdirectory and then crash due to recursiveness. This is
listed as a bug at https://github.com/seshnadathur/Revolver/issues/7 .

This commit fixes the bug by setting a default handle "myhandle"
if handle is an empty string.

_Side effect:_ this commit also solves a bug that I haven't posted: if
`output_folder` does not have a trailing slash, then the zobov
directory handling strategies are again unlikely to do what is
expected by the user.  It's easy to use a python library function to
add a trailing slash in an OS-independent way, so that is done
in this commit too.